### PR TITLE
Add support email option to menu

### DIFF
--- a/bcource/templates/nav.html
+++ b/bcource/templates/nav.html
@@ -93,6 +93,8 @@
 							href="{{ url_for('user_bp.update') }}">Account Details</a></li>
 						<li><a class="dropdown-item"
 							href="{{ url_for('user_bp.settings') }}">Account Settings</a></li>
+						<li><a class="dropdown-item"
+							href="{{ url_for('user_bp.support') }}">Contact Support</a></li>
 {#
                          <li><a class="dropdown-item"
                               href="{{ url_for('user_bp.message') }}">Send Message</a></li>
@@ -136,6 +138,9 @@
 						<li><a class="dropdown-item"
 							href="{{ url_for_security('register') }}{%- if 'next' in request.args -%}?next={{ request.args.next|urlencode }}{%- endif -%}">{{
 								_fsdomain('Register') }}</a></li> {% endif -%}
+						<li><hr class="dropdown-divider"></li>
+						<li><a class="dropdown-item"
+							href="{{ url_for('user_bp.support_public') }}">{{ _fsdomain('Contact Support') }}</a></li>
                                         {% if security.recoverable
 						-%}
 						<li><a class="dropdown-item"

--- a/bcource/user/forms.py
+++ b/bcource/user/forms.py
@@ -170,3 +170,46 @@ class AccountDetailsForm(FlaskForm):
     id  = MyHiddenField('id')
 
     
+class SupportForm(FlaskForm):
+    form_description = _l("Contact Support")
+    formclass =  "col-md-10"
+    
+    subject = MyStringField(
+        _l('Subject'), [validators.DataRequired()],
+        divclass = "col-md-12 mt-1",
+        render_kw={"class": "position-relative form-control"})
+
+    body = MyTextAreaField(
+        _l('Describe your issue or question'), [validators.DataRequired()],
+        divclass = "col-md-12 mt-1",
+        render_kw={"class": "position-relative form-control", "rows": "8"})
+
+    url = MyHiddenField()
+    
+
+class PublicSupportForm(FlaskForm):
+    form_description = _l("Contact Support")
+    formclass =  "col-md-10"
+    
+    name = MyStringField(
+        _l('Your Name'), [validators.DataRequired()],
+        divclass = "col-md-12 mt-1",
+        render_kw={"class": "position-relative form-control"})
+    
+    email = MyEmailField(
+        _l('Your Email'), [validators.DataRequired(), validators.Email()],
+        divclass = "col-md-12 mt-1",
+        render_kw={"class": "position-relative form-control"})
+    
+    subject = MyStringField(
+        _l('Subject'), [validators.DataRequired()],
+        divclass = "col-md-12 mt-1",
+        render_kw={"class": "position-relative form-control"})
+
+    body = MyTextAreaField(
+        _l('Describe your issue or question'), [validators.DataRequired()],
+        divclass = "col-md-12 mt-1",
+        render_kw={"class": "position-relative form-control", "rows": "8"})
+
+    url = MyHiddenField()
+    

--- a/bcource/user/templates/user/support.html
+++ b/bcource/user/templates/user/support.html
@@ -1,0 +1,72 @@
+{% extends 'base-form.html' %}
+
+{% set menu="Contact Support" %}
+
+{% block nav %}
+    {% include 'nav.html' %}
+{% endblock %}
+
+{% block content %}
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">
+                    <h4 class="mb-0">{{ _('Contact Support') }}</h4>
+                </div>
+                <div class="card-body">
+                    <p class="text-muted">
+                        {{ _('Having an issue or need help? Send us a message and our support team will get back to you as soon as possible.') }}
+                    </p>
+                    
+                    <form method="POST" action="{{ url_for('user_bp.support') }}">
+                        {{ form.csrf_token }}
+                        {{ form.url }}
+                        
+                        <div class="mb-3">
+                            {{ form.subject.label(class="form-label") }}
+                            {{ form.subject(class="form-control") }}
+                            {% if form.subject.errors %}
+                                <div class="text-danger small">
+                                    {% for error in form.subject.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        </div>
+                        
+                        <div class="mb-3">
+                            {{ form.body.label(class="form-label") }}
+                            {{ form.body(class="form-control", rows="8", 
+                                placeholder=_("Please describe your issue or question in detail...")) }}
+                            {% if form.body.errors %}
+                                <div class="text-danger small">
+                                    {% for error in form.body.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        </div>
+                        
+                        <div class="d-flex justify-content-between">
+                            <a href="{{ url_for('home_bp.home') }}" class="btn btn-secondary">
+                                {{ _('Cancel') }}
+                            </a>
+                            <button type="submit" class="btn btn-primary">
+                                <i class="bi bi-envelope-fill"></i> {{ _('Send to Support') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+                <div class="card-footer text-muted">
+                    <small>
+                        <i class="bi bi-info-circle"></i> 
+                        {{ _('Your current email address') }}: <strong>{{ current_user.email }}</strong><br>
+                        {{ _('We will send our response to this email address.') }}
+                    </small>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/bcource/user/templates/user/support_public.html
+++ b/bcource/user/templates/user/support_public.html
@@ -1,0 +1,98 @@
+{% extends 'base-form.html' %}
+
+{% set menu="Contact Support" %}
+
+{% block nav %}
+    {% include 'nav.html' %}
+{% endblock %}
+
+{% block content %}
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">
+                    <h4 class="mb-0">{{ _('Contact Support') }}</h4>
+                </div>
+                <div class="card-body">
+                    <p class="text-muted">
+                        {{ _('Having an issue or need help? Send us a message and our support team will get back to you as soon as possible.') }}
+                    </p>
+                    
+                    <form method="POST" action="{{ url_for('user_bp.support_public') }}">
+                        {{ form.csrf_token }}
+                        {{ form.url }}
+                        
+                        <div class="mb-3">
+                            {{ form.name.label(class="form-label") }}
+                            {{ form.name(class="form-control") }}
+                            {% if form.name.errors %}
+                                <div class="text-danger small">
+                                    {% for error in form.name.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        </div>
+                        
+                        <div class="mb-3">
+                            {{ form.email.label(class="form-label") }}
+                            {{ form.email(class="form-control", 
+                                placeholder=_("We'll use this email to send you our response")) }}
+                            {% if form.email.errors %}
+                                <div class="text-danger small">
+                                    {% for error in form.email.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        </div>
+                        
+                        <div class="mb-3">
+                            {{ form.subject.label(class="form-label") }}
+                            {{ form.subject(class="form-control") }}
+                            {% if form.subject.errors %}
+                                <div class="text-danger small">
+                                    {% for error in form.subject.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        </div>
+                        
+                        <div class="mb-3">
+                            {{ form.body.label(class="form-label") }}
+                            {{ form.body(class="form-control", rows="8", 
+                                placeholder=_("Please describe your issue or question in detail...")) }}
+                            {% if form.body.errors %}
+                                <div class="text-danger small">
+                                    {% for error in form.body.errors %}
+                                        {{ error }}
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
+                        </div>
+                        
+                        <div class="d-flex justify-content-between">
+                            <a href="{{ url_for('home_bp.home') }}" class="btn btn-secondary">
+                                {{ _('Cancel') }}
+                            </a>
+                            <button type="submit" class="btn btn-primary">
+                                <i class="bi bi-envelope-fill"></i> {{ _('Send to Support') }}
+                            </button>
+                        </div>
+                    </form>
+                </div>
+                <div class="card-footer text-muted">
+                    <small>
+                        <i class="bi bi-info-circle"></i> 
+                        {{ _('Already have an account?') }} 
+                        <a href="{{ url_for_security('login') }}">{{ _('Sign in') }}</a>
+                        {{ _('for faster support and access to your message history.') }}
+                    </small>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/bcource/user/user_views.py
+++ b/bcource/user/user_views.py
@@ -4,9 +4,9 @@ from flask_security import current_user
 from bcource.models import UserSettings, Message, User, UserMessageAssociation, Role, MessageTag, Training
 from flask import current_app as app
 from flask_security import auth_required
-from bcource.user.forms  import AccountDetailsForm, UserSettingsForm, UserMessages, MessageActionform
+from bcource.user.forms  import AccountDetailsForm, UserSettingsForm, UserMessages, MessageActionform, SupportForm
 from werkzeug.security import generate_password_hash, check_password_hash
-from bcource.helpers import get_url, message_date
+from bcource.helpers import get_url, message_date, config_value as cv
 from bcource.user.user_status import UserProfileChecks, UserProfileSystemChecks
 from bcource import db, menu_structure
 from setuptools._vendor.jaraco.functools import except_
@@ -368,5 +368,137 @@ def settings():
         return redirect(url)
     
     return render_template("user/update-settings.html", form=form)
+
+
+@user_bp.route('/support', methods=['GET', 'POST'])
+@auth_required()
+def support():
+    form = SupportForm()
+    
+    url = get_url(form)
+    
+    if form.validate_on_submit():
+        # Find or create the support user
+        support_user = User.query.filter_by(email=cv('SUPPORT_EMAIL')).first()
+        if not support_user:
+            # Create support user if it doesn't exist
+            support_user = User(
+                email=cv('SUPPORT_EMAIL'),
+                first_name='Support',
+                last_name='Team',
+                active=True
+            )
+            db.session.add(support_user)
+            db.session.commit()
+        
+        # Send email to support
+        msg = SendEmail(
+            envelop_to=[support_user],
+            envelop_from=current_user,
+            body=f"""
+            <p><strong>Support Request from {current_user.fullname} ({current_user.email})</strong></p>
+            <hr>
+            <p><strong>Subject:</strong> {form.subject.data}</p>
+            <p><strong>Message:</strong></p>
+            <p>{form.body.data}</p>
+            """,
+            subject=f"Support Request: {form.subject.data}",
+            taglist=['support', 'email']
+        )
+        msg.send()
+        
+        # Also send a copy to the user for their records
+        confirmation_msg = SendEmail(
+            envelop_to=[current_user],
+            envelop_from=support_user,
+            body=f"""
+            <p>Thank you for contacting support. We have received your message and will respond as soon as possible.</p>
+            <hr>
+            <p><strong>Your message:</strong></p>
+            <p><strong>Subject:</strong> {form.subject.data}</p>
+            <p>{form.body.data}</p>
+            """,
+            subject=f"Support Request Received: {form.subject.data}",
+            taglist=['support', 'email']
+        )
+        confirmation_msg.send()
+        
+        flash(_("Your message has been sent to support. You will receive a response soon."), 'success')
+        return redirect(url_for('home_bp.home'))
+    
+    return render_template("user/support.html", form=form)
+
+
+@user_bp.route('/support-public', methods=['GET', 'POST'])
+def support_public():
+    """Support form for non-authenticated users"""
+    form = PublicSupportForm()
+    
+    url = get_url(form)
+    
+    if form.validate_on_submit():
+        # Find or create the support user
+        support_user = User.query.filter_by(email=cv('SUPPORT_EMAIL')).first()
+        if not support_user:
+            # Create support user if it doesn't exist
+            support_user = User(
+                email=cv('SUPPORT_EMAIL'),
+                first_name='Support',
+                last_name='Team',
+                active=True
+            )
+            db.session.add(support_user)
+            db.session.commit()
+        
+        # Create or find the sender user
+        sender_user = User.query.filter_by(email=form.email.data).first()
+        if not sender_user:
+            # Create a temporary user for tracking purposes
+            sender_user = User(
+                email=form.email.data,
+                first_name=form.name.data.split()[0] if form.name.data else 'Guest',
+                last_name=' '.join(form.name.data.split()[1:]) if form.name.data and len(form.name.data.split()) > 1 else 'User',
+                active=False  # Not an active user, just for message tracking
+            )
+            db.session.add(sender_user)
+            db.session.commit()
+        
+        # Send email to support
+        msg = SendEmail(
+            envelop_to=[support_user],
+            envelop_from=sender_user,
+            body=f"""
+            <p><strong>Support Request from {form.name.data} ({form.email.data})</strong></p>
+            <p><em>Note: This is from a non-authenticated user</em></p>
+            <hr>
+            <p><strong>Subject:</strong> {form.subject.data}</p>
+            <p><strong>Message:</strong></p>
+            <p>{form.body.data}</p>
+            """,
+            subject=f"Support Request: {form.subject.data}",
+            taglist=['support', 'email', 'public']
+        )
+        msg.send()
+        
+        # Send confirmation to the user
+        confirmation_msg = SendEmail(
+            envelop_to=[sender_user],
+            envelop_from=support_user,
+            body=f"""
+            <p>Thank you for contacting support. We have received your message and will respond to {form.email.data} as soon as possible.</p>
+            <hr>
+            <p><strong>Your message:</strong></p>
+            <p><strong>Subject:</strong> {form.subject.data}</p>
+            <p>{form.body.data}</p>
+            """,
+            subject=f"Support Request Received: {form.subject.data}",
+            taglist=['support', 'email', 'public']
+        )
+        confirmation_msg.send()
+        
+        flash(_("Your message has been sent to support. You will receive a response at the email address provided."), 'success')
+        return redirect(url_for('home_bp.home'))
+    
+    return render_template("user/support_public.html", form=form)
 
 

--- a/config.py
+++ b/config.py
@@ -121,6 +121,8 @@ class Config:
     BCOURSE_SYSTEM_USER = environ.get("BCOURSE_SYSTEM_USER", 'do-not-reply@bcourse.nl')
     BCOURSE_SYSTEM_FIRSTNAME = environ.get("BCOURSE_SYSTEM_FIRSTNAME", 'Bcourse')
     BCOURSE_SYSTEM_LASTNAME = environ.get("BCOURSE_SYSTEM_LASTNAME", 'Reservation System')
+    
+    BCOURSE_SUPPORT_EMAIL = environ.get("BCOURSE_SUPPORT_EMAIL", 'support@bcourse.nl')
 
     SECURITY_AUTHORIZE_REQUEST = {'admin.index': [ BCOURSE_SUPER_USER_ROLE, 'cms-admin' ]}
     


### PR DESCRIPTION
Add a 'Contact Support' email option to the user menu and public menu to allow users to easily send support requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d07f242-3533-4f14-94cc-233d0148e0bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d07f242-3533-4f14-94cc-233d0148e0bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

